### PR TITLE
Introduce graceful shutdown interface for MyTCPProtocol

### DIFF
--- a/hw1/protocol.py
+++ b/hw1/protocol.py
@@ -14,6 +14,9 @@ class UDPBasedProtocol:
         msg, addr = self.udp_socket.recvfrom(n)
         return msg
 
+    def close(self):
+        self.udp_socket.close()
+
 
 class MyTCPProtocol(UDPBasedProtocol):
     def __init__(self, *args, **kwargs):

--- a/hw1/protocol_test.py
+++ b/hw1/protocol_test.py
@@ -41,6 +41,10 @@ def run_echo_test(iterations, msg_size):
     client_thread.join()
     server_thread.join()
 
+    # graceful shutdown
+    a.close()
+    b.close()
+
 
 current_netem_state = None
 


### PR DESCRIPTION
Проблема заключалась в том, что в исполнении тестов последовательно создаются TcpClient'ы и не закрываются (2 на тест). Таким образом, например, в реализации с thread'ами (N threads per client), к моменту последнего теста накапливалось 20 * N * 2 активных тредов, что в итоге планировщику тредов делало очень больно, для прохождения тестов с тредами приходилось делать разные трюки по их удалению. Это ревью добавляет возможность добавить graceful shutdown для своего сокета