### PR TITLE
Check netem cmd sucess and pytest-timeout pkg existence

### DIFF
--- a/hw/1_tcp/conftest.py
+++ b/hw/1_tcp/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+import pkgutil
+
+def pytest_configure(config):
+    found_pytest_timeout = False
+    for pkg in pkgutil.iter_modules():
+        if pkg.name == "pytest_timeout":
+             found_pytest_timeout = True
+             break
+    if not found_pytest_timeout:
+        pytest.exit(
+            "pytest-timeout not found. Please install it via package manager " +
+            "(usually, package name is python3-pytest-timeout) or pip " +
+            "(sudo pip install python3-pytest-timeout)."
+        )

--- a/hw/1_tcp/test.sh
+++ b/hw/1_tcp/test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-pytest -v protocol_test.py -o log_cli=true --durations=0
+pytest -v protocol_test.py -o log_cli=true --durations=0 --capture=sys


### PR DESCRIPTION
Изменения добавляют проверку успешности выполнения netem. В частности, отловим отсутствие утилиты `tc`, если кто запускает с мака или другой ОС.

Еще добавим проверку того, что пакет `pytest-timeout` установлен. Без него таймауты не работают (не должны работать), если кто-то запускает на локальном линуксе (правда, выйдет куча варнингов, что `pytest.mark.timeout` не зарегистрирован). Проверяется только при запуске через pytest, в функции настройки конфига (ее вызывает сам pytest).

Требуется проверить, что на маке отлавливается отсутствие netem и выходит сообщение, что надо запускать на линуксе. У меня мака нет, не могу проверить.